### PR TITLE
Use test DB URI for server and close server after tests

### DIFF
--- a/tests/testdb.test.js
+++ b/tests/testdb.test.js
@@ -1,5 +1,9 @@
 const request = require('supertest');
 const mongoose = require('mongoose');
+
+const TEST_URI = process.env.MONGODB_TEST_URI || 'mongodb://localhost:27017/cryptotribes_test';
+process.env.MONGODB_URI = TEST_URI;
+
 const app = require('../server/server');
 const Village = require('../models/Village');
 const Building = require('../models/Building');
@@ -18,6 +22,10 @@ beforeAll(async () => {
 afterAll(async () => {
   await mongoose.connection.db.dropDatabase();
   await mongoose.disconnect();
+
+  if (typeof app?.close === 'function') {
+    await new Promise((resolve) => app.close(resolve));
+  }
 });
 
 // Authentication tests


### PR DESCRIPTION
## Summary
- ensure `MONGODB_URI` points to the test database before loading the server
- close the server after all tests when possible

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f1248ff88832d9e14ee8c681fb03a