### PR TITLE
Add Stripe mock for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@jest/globals": "^29.6.4",
     "jest": "^29.6.4",
     "nodemon": "^3.0.1",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "stripe": "^11.0.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/tests/__mocks__/stripe.js
+++ b/tests/__mocks__/stripe.js
@@ -1,0 +1,12 @@
+const stripe = jest.fn(() => ({
+  checkout: {
+    sessions: {
+      create: jest.fn().mockResolvedValue({ id: 'session_mock', url: 'http://stripe.mock/session' })
+    }
+  },
+  webhooks: {
+    constructEvent: jest.fn(() => ({}))
+  }
+}));
+
+module.exports = stripe;

--- a/tests/testdb.test.js
+++ b/tests/testdb.test.js
@@ -1,3 +1,4 @@
+jest.mock('stripe');
 const request = require('supertest');
 const mongoose = require('mongoose');
 


### PR DESCRIPTION
## Summary
- set up Stripe as a dev dependency
- add manual Jest mock for Stripe
- mock Stripe in integration tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1edd19f8832daac71f3264187394