### PR TITLE
Fix handlers to use userIdObject

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -213,15 +213,10 @@ app.get('/api/buildings/:villageId', requireAuth, async (req, res) => {
 // Построить/улучшить здание
 app.post('/api/build', requireAuth, async (req, res) => {
     const { villageId, buildingType } = req.body;
-    
     try {
-codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.upgradeBuilding(req.session.userId, villageId, buildingType);
-        res.status(200).json(result);
-
+    
         const result = await gameLogic.upgradeBuilding(req.userIdObject, villageId, buildingType);
         res.json(result);
- codex-test
     } catch (error) {
         logger.error('Ошибка строительства:', error);
         res.status(400).json({ error: error.message });
@@ -245,13 +240,9 @@ app.post('/api/train', requireAuth, async (req, res) => {
     const { villageId, troopType, amount } = req.body;
     
     try {
- codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.trainTroops(req.session.userId, villageId, troopType, amount);
-        res.status(200).json(result);
 
         const result = await gameLogic.trainTroops(req.userIdObject, villageId, troopType, amount);
         res.json(result);
-codex-test
     } catch (error) {
         logger.error('Ошибка обучения войск:', error);
         res.status(400).json({ error: error.message });
@@ -274,13 +265,9 @@ app.post('/api/attack', requireAuth, async (req, res) => {
     const { fromVillageId, toVillageId, troops } = req.body;
     
     try {
-codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.attackVillage(req.session.userId, fromVillageId, toVillageId, troops);
-        res.status(200).json(result);
 
         const result = await gameLogic.attackVillage(req.userIdObject, fromVillageId, toVillageId, troops);
         res.json(result);
- codex-test
     } catch (error) {
         logger.error('Ошибка атаки:', error);
         res.status(400).json({ error: error.message });
@@ -294,13 +281,9 @@ app.post('/api/tribe/create', requireAuth, async (req, res) => {
     const { name, tag } = req.body;
     
     try {
- codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.createTribe(req.session.userId, name, tag);
-        res.status(200).json(result);
 
         const result = await gameLogic.createTribe(req.userIdObject, name, tag);
         res.json(result);
- codex-test
     } catch (error) {
         logger.error('Ошибка создания племени:', error);
         res.status(400).json({ error: error.message });
@@ -323,13 +306,9 @@ app.post('/api/tribe/join', requireAuth, async (req, res) => {
     const { tribeId } = req.body;
     
     try {
- codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.joinTribe(req.session.userId, tribeId);
-        res.status(200).json(result);
 
         const result = await gameLogic.joinTribe(req.userIdObject, tribeId);
         res.json(result);
- codex-test
     } catch (error) {
         logger.error('Ошибка присоединения к племени:', error);
         res.status(400).json({ error: error.message });
@@ -420,13 +399,9 @@ app.post('/api/speed-up', requireAuth, async (req, res) => {
     const { actionId, type } = req.body;
     
     try {
- codex/починить-ветку-codex-test-backend-cryptotribes
-        const result = await gameLogic.speedUpAction(req.session.userId, actionId, type);
-        res.status(200).json(result);
 
         const result = await gameLogic.speedUpAction(req.userIdObject, actionId, type);
         res.json(result);
- codex-test
     } catch (error) {
         logger.error('Ошибка ускорения:', error);
         res.status(400).json({ error: error.message });


### PR DESCRIPTION
## Summary
- clean up leftover merge markers
- simplify handler result logic to use `req.userIdObject`

## Testing
- `node -c server/server.js`


------
https://chatgpt.com/codex/tasks/task_e_685f1eddb810832dae70b543b89bb20e